### PR TITLE
Added testhelper for running unit tests against actual database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20221012175353-8cb6718a9bcc
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	github.com/wiggin77/merror v1.0.5 // indirect
+	github.com/wiggin77/merror v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,10 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
@@ -612,6 +614,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-migrate/migrate/v4 v4.15.2 h1:vU+M05vs6jWHKDdmE1Ecwj0BznygFc4QsdRe2E/L7kc=
 github.com/golang-migrate/migrate/v4 v4.15.2/go.mod h1:f2toGLkYqD3JH+Todi4aZ2ZdbeUNx4sIwiOK96rE9Lw=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
@@ -730,6 +733,7 @@ github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -756,6 +760,7 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -765,6 +770,7 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.4 h1:NVdrSdFRt3SkZtNckJ6tog7gbpRrcbOjQi/rgF7JYWQ=
 github.com/hashicorp/go-plugin v1.4.4/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
@@ -984,8 +990,10 @@ github.com/mattermost/mattermost-plugin-api v0.1.4 h1:87RUWt7my67CJWPy1p8lsqnKXl
 github.com/mattermost/mattermost-plugin-api v0.1.4/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221012175353-8cb6718a9bcc h1:Fen4E5vRUDTxrFb2tClzIev7v57EZakEPOzuG5HvYWo=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221012175353-8cb6718a9bcc/go.mod h1:Eu6nct2XZRPlHHW4MfZtjli5bY7G9QomKcor/lm+0Sw=
+github.com/mattermost/morph v0.0.0-20220804124441-62627668af80 h1:Sip/imqvGBi2XZiN/bfHjQ6T/UEvaRwqjFzy4PX9lQk=
 github.com/mattermost/morph v0.0.0-20220804124441-62627668af80/go.mod h1:xo0ljDknTpPxEdhhrUdwhLCexIsYyDKS6b41HqG8wGU=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
+github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -1023,6 +1031,7 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -1436,7 +1445,6 @@ github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wiggin77/merror v1.0.2/go.mod h1:uQTcIU0Z6jRK4OwqganPYerzQxSFJ4GSHM3aurxxQpg=
-github.com/wiggin77/merror v1.0.4 h1:XxFLEevmQQfgJW2AxhapuMG7C1fQqfbim/XyUmYv/ZM=
 github.com/wiggin77/merror v1.0.4/go.mod h1:H2ETSu7/bPE0Ymf4bEwdUoo73OOEkdClnoRisfw0Nm0=
 github.com/wiggin77/merror v1.0.5 h1:P+lzicsn4vPMycAf2mFf7Zk6G9eco5N+jB1qJ2XW3ME=
 github.com/wiggin77/merror v1.0.5/go.mod h1:H2ETSu7/bPE0Ymf4bEwdUoo73OOEkdClnoRisfw0Nm0=
@@ -1522,6 +1530,7 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
@@ -1733,6 +1742,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/channels/archiver.go
+++ b/server/channels/archiver.go
@@ -14,7 +14,7 @@ type Reason string
 
 const (
 	ReasonDone      Reason = "completed normally"
-	ReasonCancelled Reason = "cancelled"
+	ReasonCancelled Reason = "canceled"
 	ReasonTimeout   Reason = "timed out"
 	ReasonError     Reason = "error"
 )
@@ -34,7 +34,7 @@ type ArchiverResults struct {
 	start            time.Time
 }
 
-func ArchiveChannels(db *sql.DB, opts ArchiverOpts, ctx context.Context) (results *ArchiverResults, retErr error) {
+func ArchiveChannels(ctx context.Context, db *sql.DB, opts ArchiverOpts) (results *ArchiverResults, retErr error) {
 	results = &ArchiverResults{
 		ExitReason: ReasonDone,
 		Warnings:   merror.New(),
@@ -51,9 +51,14 @@ func ArchiveChannels(db *sql.DB, opts ArchiverOpts, ctx context.Context) (result
 		results.Duration = time.Since(results.start)
 	}()
 
-	return results, archiveChannels(db, opts, results, ctx)
+	return results, archiveChannels(ctx, db, opts, results)
 }
 
-func archiveChannels(db *sql.DB, opts ArchiverOpts, results *ArchiverResults, ctx context.Context) error {
+func archiveChannels(ctx context.Context, db *sql.DB, opts ArchiverOpts, results *ArchiverResults) error {
+	_ = ctx
+	_ = db
+	_ = opts
+	_ = results
+
 	return errors.New("not implemented yet")
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -32,7 +32,7 @@ type Plugin struct {
 	SQLStore *store.SQLStore
 }
 
-func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	switch r.URL.Path {
@@ -49,14 +49,13 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 
 func (p *Plugin) OnActivate() error {
 	p.Client = pluginapi.NewClient(p.API, p.Driver)
-	SQLStore, err := store.New(p.Client)
+	SQLStore, err := store.New(p.Client.Store, &p.Client.Log)
 	if err != nil {
 		p.Client.Log.Error("cannot create SQLStore", "err", err)
 		return err
 	}
 	p.SQLStore = SQLStore
 
-	// not implemented yet
 	return nil
 }
 

--- a/server/store/channels.go
+++ b/server/store/channels.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 

--- a/server/store/channels_test.go
+++ b/server/store/channels_test.go
@@ -2,13 +2,201 @@ package store
 
 import (
 	"testing"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+)
+
+var (
+	yearAgo = model.GetMillisForTime(time.Now().AddDate(-1, 0, 0))
+	weekAgo = model.GetMillisForTime(time.Now().AddDate(0, 0, -7))
 )
 
 func TestSQLStore_GetStaleChannels(t *testing.T) {
 	th := SetupHelper(t).SetupBasic(t)
-	defer th.tearDown()
+	defer th.TearDown()
 
-	assert.Nil(t, th.Team1.IsValid())
+	const channelCount = 10
+	const postCount = 10
+
+	// create a bunch of channels
+	channels, err := th.CreateChannels(channelCount, "stale-test", th.User1.Id, th.Team1.Id)
+	require.NoError(t, err)
+
+	var posts []*model.Post
+	var reactions []*model.Reaction
+
+	// add some posts and reactions
+	for _, channel := range channels {
+		posts, err = th.CreatePosts(postCount, th.User1.Id, channel.Id)
+		require.NoError(t, err)
+
+		reactions, err = th.CreateReactions(posts, th.User1.Id)
+		require.NoError(t, err)
+		assert.NotEmpty(t, reactions)
+	}
+
+	// channel 0 - adjust all timestamps to 1 year old (stale)
+	setTimestamps(t, th, "channels", channels[0].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "posts", channels[0].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "reactions", channels[0].Id, yearAgo, yearAgo, 0)
+
+	// channel 1 - posts and reactions deleted a year ago (stale)
+	setTimestamps(t, th, "channels", channels[1].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "posts", channels[1].Id, yearAgo, yearAgo, yearAgo)
+	setTimestamps(t, th, "reactions", channels[1].Id, yearAgo, yearAgo, yearAgo)
+
+	// channels 2-4 - all timestamps current (not stale)
+
+	// channel 5 - posts and reactions deleted a week ago (not stale)
+	setTimestamps(t, th, "channels", channels[5].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "posts", channels[5].Id, yearAgo, weekAgo, 0)
+	setTimestamps(t, th, "reactions", channels[5].Id, yearAgo, weekAgo, 0)
+
+	// channel 6 - old channel timstamps, new posts (not stale)
+	setTimestamps(t, th, "channels", channels[6].Id, yearAgo, yearAgo, 0)
+
+	// channel 7 - deleted channel (not stale)
+	setTimestamps(t, th, "channels", channels[7].Id, yearAgo, yearAgo, weekAgo)
+
+	// channel 8 - adjust post timestamps to 1 year old, leave reactions (not stale)
+	setTimestamps(t, th, "channels", channels[8].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "posts", channels[8].Id, yearAgo, yearAgo, 0)
+
+	// channel 9 - adjust all post/reaction timestamps to 1 week old (not stale)
+	setTimestamps(t, th, "channels", channels[9].Id, yearAgo, weekAgo, 0)
+	setTimestamps(t, th, "posts", channels[9].Id, yearAgo, weekAgo, 0)
+	setTimestamps(t, th, "reactions", channels[9].Id, weekAgo, weekAgo, 0)
+
+	// fetch channels stale for 30 days or more
+	staleChannels, more, err := th.Store.GetStaleChannels(30, 0, 0, nil)
+	require.NoError(t, err)
+	assert.False(t, more)
+	assert.Len(t, staleChannels, 2)
+
+	// only channels 0,1 are stale
+	staleIDs := make([]string, 0, len(staleChannels))
+	for _, ch := range staleChannels {
+		staleIDs = append(staleIDs, ch.Id)
+	}
+	assert.ElementsMatch(t, staleIDs, []string{channels[0].Id, channels[1].Id})
+
+	for i, ch := range channels {
+		t.Log(i, ch.Id)
+	}
+}
+
+func TestSQLStore_GetStaleChannelsEmptyChannel(t *testing.T) {
+	th := SetupHelper(t).SetupBasic(t)
+	defer th.TearDown()
+
+	const channelCount = 3
+
+	channels, err := th.CreateChannels(channelCount, "empty-channel-test", th.User1.Id, th.Team1.Id)
+	require.NoError(t, err)
+
+	// make 0,2 stale
+	setTimestamps(t, th, "channels", channels[0].Id, yearAgo, yearAgo, 0)
+	setTimestamps(t, th, "channels", channels[2].Id, yearAgo, yearAgo, 0)
+
+	staleChannels, more, err := th.Store.GetStaleChannels(30, 0, 0, nil)
+	require.NoError(t, err)
+	assert.False(t, more)
+
+	assert.Len(t, staleChannels, 2)
+
+	staleIDs := extractChannelIDs(staleChannels)
+	assert.ElementsMatch(t, staleIDs, []string{channels[0].Id, channels[2].Id})
+}
+
+func TestSQLStore_GetStaleChannelsPagnation(t *testing.T) {
+	th := SetupHelper(t).SetupBasic(t)
+	defer th.TearDown()
+
+	const channelCount = 100
+
+	channels, err := th.CreateChannels(channelCount, "pagnation-test", th.User2.Id, th.Team2.Id)
+	require.NoError(t, err)
+
+	// make 50 of them stale
+	for i, ch := range channels {
+		if i < 50 {
+			setTimestamps(t, th, "channels", ch.Id, yearAgo, yearAgo, 0)
+		}
+	}
+
+	const pageSize = 10
+	var page = 0
+	staleChannels := make([]*model.Channel, 0)
+	loopCount := 0
+
+	// fetch channels stale for 30 days or more
+	for {
+		fetchedChannels, more, err := th.Store.GetStaleChannels(30, page*pageSize, pageSize, nil)
+		require.NoError(t, err)
+		page++
+		loopCount++
+
+		staleChannels = append(staleChannels, fetchedChannels...)
+
+		if !more {
+			break
+		}
+	}
+
+	assert.Equal(t, loopCount, 5)
+	assert.Len(t, staleChannels, 50)
+
+	staleIDs := extractChannelIDs(staleChannels)
+	channelIDs := extractChannelIDs(channels[:50])
+	assert.ElementsMatch(t, staleIDs, channelIDs)
+}
+
+func setTimestamps(t *testing.T, th *TestHelper, table string, channelID string, createAt, updateAt, deleteAt int64) {
+	query := th.Store.builder.Update(table)
+
+	if createAt >= 0 {
+		query = query.Set("createat", createAt)
+	}
+	if updateAt >= 0 {
+		query = query.Set("updateat", updateAt)
+	}
+	if deleteAt >= 0 {
+		query = query.Set("deleteat", deleteAt)
+	}
+
+	switch table {
+	case "channels":
+		query = query.Where(sq.Eq{"id": channelID})
+	case "posts":
+		query = query.Where(sq.Eq{"channelid": channelID})
+	case "reactions":
+		// `reactions.channelid` does not exist in all server versions we need to support, therefore
+		// we need to update all reactions belonging to posts in the channel.
+		selectQuery := th.Store.builder.Select("id").From("posts").Where(sq.Eq{"channelid": channelID})
+		query = query.Where(selectQuery.Prefix("postid IN (").Suffix(")"))
+	default:
+		panic("invalid table name")
+	}
+
+	result, err := query.Exec()
+	require.NoError(t, err)
+
+	rowsAffected, err := result.RowsAffected()
+	require.NoError(t, err)
+
+	t.Logf("setTimestamps for %s, %d rows affected.", table, rowsAffected)
+}
+
+func extractChannelIDs(channels []*model.Channel) []string {
+	ids := make([]string, 0, len(channels))
+	for _, ch := range channels {
+		ids = append(ids, ch.Id)
+	}
+	return ids
 }

--- a/server/store/channels_test.go
+++ b/server/store/channels_test.go
@@ -1,0 +1,14 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLStore_GetStaleChannels(t *testing.T) {
+	th := SetupHelper(t).SetupBasic(t)
+	defer th.tearDown()
+
+	assert.Nil(t, th.Team1.IsValid())
+}

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -46,6 +46,8 @@ func New(src SQLStoreSource, logger Logger) (*SQLStore, error) {
 		db.MapperFunc(func(s string) string { return s })
 	}
 
+	builder = builder.RunWith(db)
+
 	return &SQLStore{
 		db,
 		builder,

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -1,40 +1,54 @@
 package store
 
 import (
+	"database/sql"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
-	pluginapi "github.com/mattermost/mattermost-plugin-api"
+
 	"github.com/mattermost/mattermost-server/v6/model"
 )
+
+type SQLStoreSource interface {
+	GetMasterDB() (*sql.DB, error)
+	DriverName() string
+}
+
+type Logger interface {
+	Error(message string, keyValuePairs ...interface{})
+	Warn(message string, keyValuePairs ...interface{})
+	Info(message string, keyValuePairs ...interface{})
+	Debug(message string, keyValuePairs ...interface{})
+}
 
 type SQLStore struct {
 	db      *sqlx.DB
 	builder sq.StatementBuilderType
-	logger  pluginapi.LogService
+	logger  Logger
 }
 
 // New constructs a new instance of SQLStore.
-func New(client *pluginapi.Client) (*SQLStore, error) {
+func New(src SQLStoreSource, logger Logger) (*SQLStore, error) {
 	var db *sqlx.DB
 
-	origDB, err := client.Store.GetMasterDB()
+	origDB, err := src.GetMasterDB()
 	if err != nil {
 		return nil, err
 	}
-	db = sqlx.NewDb(origDB, client.Store.DriverName())
+	db = sqlx.NewDb(origDB, src.DriverName())
 
 	builder := sq.StatementBuilder.PlaceholderFormat(sq.Question)
-	if client.Store.DriverName() == model.DatabaseDriverPostgres {
+	if src.DriverName() == model.DatabaseDriverPostgres {
 		builder = builder.PlaceholderFormat(sq.Dollar)
 	}
 
-	if client.Store.DriverName() == model.DatabaseDriverMysql {
+	if src.DriverName() == model.DatabaseDriverMysql {
 		db.MapperFunc(func(s string) string { return s })
 	}
 
 	return &SQLStore{
 		db,
 		builder,
-		client.Log,
+		logger,
 	}, nil
 }

--- a/server/store/testhelper.go
+++ b/server/store/testhelper.go
@@ -18,8 +18,10 @@ type TestHelper struct {
 
 	Store *SQLStore
 
-	Team1 *model.Team
-	Team2 *model.Team
+	Team1    *model.Team
+	Team2    *model.Team
+	Channel1 *model.Channel
+	Channel2 *model.Channel
 }
 
 func SetupHelper(t *testing.T) *TestHelper {
@@ -48,6 +50,12 @@ func (th *TestHelper) SetupBasic(t *testing.T) *TestHelper {
 	require.NoError(t, err, "could not create teams")
 	th.Team1 = teams[0]
 	th.Team2 = teams[1]
+
+	// create some channels
+	channels, err := th.createChannels(2, "test-team")
+	require.NoError(t, err, "could not create channels")
+	th.Channel1 = channels[0]
+	th.Channel2 = channels[1]
 
 	return th
 }
@@ -78,7 +86,24 @@ func (th *TestHelper) createTeams(num int, namePrefix string) ([]*model.Team, er
 	return teams, nil
 }
 
-// storeWrapper is a wrapper for MainHelper that implemenbts SQLStoreSource interface.
+func (th *TestHelper) createChannels(num int, namePrefix string) ([]*model.Channel, error) {
+	var channels []*model.Channel
+	for i := 0; i < num; i++ {
+		channel := &model.Channel{
+			Name:        fmt.Sprintf("%s-%d", namePrefix, i),
+			DisplayName: fmt.Sprintf("%s-%d", namePrefix, i),
+			Type:        model.ChannelTypeOpen,
+		}
+		channel, err := th.mainHelper.Store.Channel().Save(channel, 1024)
+		if err != nil {
+			return nil, err
+		}
+		channels = append(channels, channel)
+	}
+	return channels, nil
+}
+
+// storeWrapper is a wrapper for MainHelper that implements SQLStoreSource interface.
 type storeWrapper struct {
 	mainHelper *testlib.MainHelper
 }

--- a/server/store/testhelper.go
+++ b/server/store/testhelper.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/store/storetest"
+	"github.com/mattermost/mattermost-server/v6/testlib"
+)
+
+type TestHelper struct {
+	mainHelper *testlib.MainHelper
+
+	Store *SQLStore
+
+	Team1 *model.Team
+	Team2 *model.Team
+}
+
+func SetupHelper(t *testing.T) *TestHelper {
+	var options = testlib.HelperOptions{
+		EnableStore: true,
+	}
+
+	th := &TestHelper{}
+	th.mainHelper = testlib.NewMainHelperWithOptions(&options)
+
+	dbStore := th.mainHelper.GetStore()
+	dbStore.DropAllTables()
+	dbStore.MarkSystemRanUnitTests()
+	th.mainHelper.PreloadMigrations()
+
+	store, err := New(storeWrapper{th.mainHelper}, &testLogger{t})
+	require.NoError(t, err, "could not create store")
+	th.Store = store
+
+	return th
+}
+
+func (th *TestHelper) SetupBasic(t *testing.T) *TestHelper {
+	// create some teams
+	teams, err := th.createTeams(2, "test-team")
+	require.NoError(t, err, "could not create teams")
+	th.Team1 = teams[0]
+	th.Team2 = teams[1]
+
+	return th
+}
+
+func (th *TestHelper) tearDown() {
+	if th.mainHelper.SQLStore != nil {
+		th.mainHelper.SQLStore.Close()
+	}
+	if th.mainHelper.Settings != nil {
+		storetest.CleanupSqlSettings(th.mainHelper.Settings)
+	}
+}
+
+func (th *TestHelper) createTeams(num int, namePrefix string) ([]*model.Team, error) {
+	var teams []*model.Team
+	for i := 0; i < num; i++ {
+		team := &model.Team{
+			Name:        fmt.Sprintf("%s-%d", namePrefix, i),
+			DisplayName: fmt.Sprintf("%s-%d", namePrefix, i),
+			Type:        model.TeamOpen,
+		}
+		team, err := th.mainHelper.Store.Team().Save(team)
+		if err != nil {
+			return nil, err
+		}
+		teams = append(teams, team)
+	}
+	return teams, nil
+}
+
+// storeWrapper is a wrapper for MainHelper that implemenbts SQLStoreSource interface.
+type storeWrapper struct {
+	mainHelper *testlib.MainHelper
+}
+
+func (sw storeWrapper) GetMasterDB() (*sql.DB, error) {
+	return sw.mainHelper.SQLStore.GetInternalMasterDB(), nil
+}
+func (sw storeWrapper) DriverName() string {
+	return *sw.mainHelper.Settings.DriverName
+}
+
+type testLogger struct {
+	tb testing.TB
+}
+
+// Error logs an error message, optionally structured with alternating key, value parameters.
+func (l *testLogger) Error(message string, keyValuePairs ...interface{}) {
+	l.log("error", message, keyValuePairs...)
+}
+
+// Warn logs an error message, optionally structured with alternating key, value parameters.
+func (l *testLogger) Warn(message string, keyValuePairs ...interface{}) {
+	l.log("warn", message, keyValuePairs...)
+}
+
+// Info logs an error message, optionally structured with alternating key, value parameters.
+func (l *testLogger) Info(message string, keyValuePairs ...interface{}) {
+	l.log("info", message, keyValuePairs...)
+}
+
+// Debug logs an error message, optionally structured with alternating key, value parameters.
+func (l *testLogger) Debug(message string, keyValuePairs ...interface{}) {
+	l.log("debug", message, keyValuePairs...)
+}
+
+func (l *testLogger) log(level string, message string, keyValuePairs ...interface{}) {
+	var args strings.Builder
+
+	if len(keyValuePairs) > 0 && len(keyValuePairs)%2 != 0 {
+		keyValuePairs = keyValuePairs[:len(keyValuePairs)-1]
+	}
+
+	for i := 0; i < len(keyValuePairs); i += 2 {
+		args.WriteString(fmt.Sprintf("%v:%v  ", keyValuePairs[i], keyValuePairs[i+1]))
+	}
+
+	l.tb.Logf("level=%s  message=%s  %s", level, message, args.String())
+}


### PR DESCRIPTION
`/server/store/testhelper.go`  contains `SetupHelper` and `SetupBasic` for creating a test helper that setups up a temporary database, adds migrations and default records, and is ready to run store unit tests against.

Requires a release-6.3 (or equivalent) branch to be checked out, and the MM_SERVER_PATH env var to be set correctly.  